### PR TITLE
Move Mode consts into an enum like class.

### DIFF
--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -28,7 +28,8 @@ CircuitPython driver for ADS1015 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
-from .ads1x15 import ADS1x15
+#pylint: disable=unused-import
+from .ads1x15 import ADS1x15, Mode
 
 # Data sample rates
 _ADS1015_CONFIG_DR = {

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -28,7 +28,8 @@ CircuitPython driver for 1115 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
-from .ads1x15 import ADS1x15
+#pylint: disable=unused-import
+from .ads1x15 import ADS1x15, Mode
 
 # Data sample rates
 _ADS1115_CONFIG_DR = {

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -41,8 +41,6 @@ _ADS1X15_POINTER_CONVERSION         = const(0x00)
 _ADS1X15_POINTER_CONFIG             = const(0x01)
 _ADS1X15_CONFIG_OS_SINGLE           = const(0x8000)
 _ADS1X15_CONFIG_MUX_OFFSET          = const(12)
-_ADS1X15_CONFIG_MODE_CONTINUOUS     = const(0x0000)
-_ADS1X15_CONFIG_MODE_SINGLE         = const(0x0100)
 _ADS1X15_CONFIG_COMP_QUE_DISABLE    = const(0x0003)
 _ADS1X15_CONFIG_GAIN = {
     2/3: 0x0000,
@@ -54,10 +52,19 @@ _ADS1X15_CONFIG_GAIN = {
 }
 # pylint: enable=bad-whitespace
 
+class Mode:
+    """An enum-like class representing possible ADC operating modes."""
+    # See datasheet "Operating Modes" section
+    # values here are masks for setting MODE bit in Config Register
+    #pylint: disable=too-few-public-methods
+    CONTINUOUS = 0x0000
+    SINGLE = 0x0100
+
+
 class ADS1x15(object):
     """Base functionality for ADS1x15 analog to digital converters."""
 
-    def __init__(self, i2c, gain=1, data_rate=None, mode=_ADS1X15_CONFIG_MODE_SINGLE,
+    def __init__(self, i2c, gain=1, data_rate=None, mode=Mode.SINGLE,
                  address=_ADS1X15_DEFAULT_ADDRESS):
         #pylint: disable=too-many-arguments
         self.buf = bytearray(3)
@@ -115,7 +122,7 @@ class ADS1x15(object):
 
     @mode.setter
     def mode(self, mode):
-        if mode != _ADS1X15_CONFIG_MODE_CONTINUOUS and mode != _ADS1X15_CONFIG_MODE_SINGLE:
+        if mode != Mode.CONTINUOUS and mode != Mode.SINGLE:
             raise ValueError("Unsupported mode.")
         self._mode = mode
 


### PR DESCRIPTION
For #21.

**NOTE** Continuous doesn't actually work right now. Probably need to change the wait-for-conversion-complete behavior. Suggest covering that in a separate issue.

```python
Adafruit CircuitPython 3.1.2 on 2019-01-07; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board, busio
>>> import adafruit_ads1x15.ads1115 as ADS
>>> from adafruit_ads1x15.analog_in import AnalogIn
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> ads = ADS.ADS1115(i2c)
>>> chan = AnalogIn(ads, ADS.P0)
>>> chan.value
2388
>>> ads.mode
256
>>> ads.mode = ADS.Mode.CONTINUOUS
>>> ads.mode
0
>>> ads.mode = ADS.Mode.SINGLE
>>> ads.mode
256
>>> chan.value
2388
>>> 
```