### PR TITLE
Support continuous mode.

### DIFF
--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -31,7 +31,6 @@ CircuitPython base class driver for ADS1015/1115 ADCs.
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15.git"
 
-import time
 from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -158,8 +158,9 @@ class ADS1x15(object):
         config |= _ADS1X15_CONFIG_COMP_QUE_DISABLE
         self._write_register(_ADS1X15_POINTER_CONFIG, config)
 
-        while not self._conversion_complete():
-            time.sleep(0.01)
+        if self.mode == Mode.SINGLE:
+            while not self._conversion_complete():
+                pass
 
         return self.get_last_result()
 


### PR DESCRIPTION
Fix for #26 

Puts the wait for conversion loop in a conditional so it doesn't get used when running in continuous mode.

**BEFORE** (gets stuck in loop)
```python
Adafruit CircuitPython 3.1.2 on 2019-01-07; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board
>>> import busio
>>> import adafruit_ads1x15.ads1115 as ADS
>>> from adafruit_ads1x15.ads1x15 import Mode
>>> from adafruit_ads1x15.analog_in import AnalogIn
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> ads = ADS.ADS1115(i2c)
>>> chan = AnalogIn(ads, ADS.P0)
>>> chan.value
8187
>>> ads.mode
256
>>> ads.mode = Mode.CONTINUOUS
>>> ads.mode
0
>>> chan.value
```

**AFTER** (yeah!)
```python
Adafruit CircuitPython 3.1.2 on 2019-01-07; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board
>>> import busio
>>> import adafruit_ads1x15.ads1115 as ADS
>>> from adafruit_ads1x15.ads1x15 import Mode
>>> from adafruit_ads1x15.analog_in import AnalogIn
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> ads = ADS.ADS1115(i2c)
>>> chan = AnalogIn(ads, ADS.P0)
>>> chan.value
8189
>>> ads.mode
256
>>> ads.mode = Mode.CONTINUOUS
>>> ads.mode
0
>>> chan.value
8189
>>>
```