### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -34,7 +34,6 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15.git"
 from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
-# pylint: disable=bad-whitespace
 _ADS1X15_DEFAULT_ADDRESS = const(0x48)
 _ADS1X15_POINTER_CONVERSION = const(0x00)
 _ADS1X15_POINTER_CONFIG = const(0x01)
@@ -49,7 +48,6 @@ _ADS1X15_CONFIG_GAIN = {
     8: 0x0800,
     16: 0x0A00,
 }
-# pylint: enable=bad-whitespace
 
 
 class Mode:

--- a/adafruit_ads1x15/analog_in.py
+++ b/adafruit_ads1x15/analog_in.py
@@ -28,10 +28,8 @@ differential ADC readings.
 * Author(s): Carter Nelson, adapted from MCP3xxx original by Brent Rubell
 """
 
-# pylint: disable=bad-whitespace
 _ADS1X15_DIFF_CHANNELS = {(0, 1): 0, (0, 3): 1, (1, 3): 2, (2, 3): 3}
 _ADS1X15_PGA_RANGE = {2 / 3: 6.144, 1: 4.096, 2: 2.048, 4: 1.024, 8: 0.512, 16: 0.256}
-# pylint: enable=bad-whitespace
 
 
 class AnalogIn:


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.