### PR TITLE
More statistics to detect bad/over polling for fast continuous example

### DIFF
--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -31,6 +31,7 @@ start = time.monotonic()
 # Read the same channel over and over
 for i in range(SAMPLES):
     data[i] = chan0.value
+    # Detect repeated values due to over polling
     if data[i] == data[i-1]:
         repeats += 1
 
@@ -40,7 +41,7 @@ total_time = end - start
 
 rate_reported = SAMPLES / total_time
 rate_actual = (SAMPLES-repeats) / total_time
-# NOTE: cannot detect conversion rates higher than polling rate
+# NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
 print("")

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -22,6 +22,8 @@ chan0 = AnalogIn(ads, ADS.P0)
 ads.mode = Mode.CONTINUOUS
 ads.data_rate = RATE
 
+repeats = 0
+
 data = [None] * SAMPLES
 
 start = time.monotonic()
@@ -29,9 +31,26 @@ start = time.monotonic()
 # Read the same channel over and over
 for i in range(SAMPLES):
     data[i] = chan0.value
+    if data[i] == data[i-1]:
+        repeats += 1
+
 
 end = time.monotonic()
 total_time = end - start
 
-print("Time of capture: {}s".format(total_time))
-print("Sample rate requested={} actual={}".format(RATE, SAMPLES / total_time))
+rate_reported = SAMPLES / total_time
+rate_actual = (SAMPLES-repeats) / total_time
+# NOTE: cannot detect conversion rates higher than polling rate
+
+print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
+print("")
+print("Configured:")
+print("    Requested       = {:5d}    sps".format(RATE))
+print("    Reported        = {:5d}    sps".format(ads.data_rate))
+print("")
+print("Actual:")
+print("    Polling Rate    = {:8.2f} sps".format(rate_reported))
+print("                      {:9.2%}".format(rate_reported / RATE))
+print("    Repeats         = {:5d}".format(repeats))
+print("    Conversion Rate = {:8.2f} sps   (estimated)".format(rate_actual))
+

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -41,7 +41,8 @@ total_time = end - start
 
 rate_reported = SAMPLES / total_time
 rate_actual = (SAMPLES - repeats) / total_time
-# NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
+# NOTE: leave input floating to pickup some random noise
+#       This cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
 print("")

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -32,7 +32,7 @@ start = time.monotonic()
 for i in range(SAMPLES):
     data[i] = chan0.value
     # Detect repeated values due to over polling
-    if data[i] == data[i-1]:
+    if data[i] == data[i - 1]:
         repeats += 1
 
 
@@ -40,7 +40,7 @@ end = time.monotonic()
 total_time = end - start
 
 rate_reported = SAMPLES / total_time
-rate_actual = (SAMPLES-repeats) / total_time
+rate_actual = (SAMPLES - repeats) / total_time
 # NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -54,4 +54,3 @@ print("    Polling Rate    = {:8.2f} sps".format(rate_reported))
 print("                      {:9.2%}".format(rate_reported / RATE))
 print("    Repeats         = {:5d}".format(repeats))
 print("    Conversion Rate = {:8.2f} sps   (estimated)".format(rate_actual))
-


### PR DESCRIPTION
Output with `RATE=250`

**_Old_**
```
$ python3 ads1x15_fast_read.py
Time of capture: 0.40527645900147036s
Sample rate requested=250 actual=2467.4514835226882
```

**_New_**
```
$ python3 ads1x15_fast_read.py
Took 0.408 s to acquire 1000 samples.

Configured:
    Requested       =   250    sps
    Reported        =   250    sps

Actual:
    Polling Rate    =  2448.00 sps
                        979.20%
    Repeats         =   901
    Conversion Rate =   242.35 sps   (estimated)
```