### PR TITLE
Wait for conversions in continuous example 

### DIFF
--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -224,3 +224,4 @@ class ADS1x15:
             else:
                 i2c.write_then_readinto(bytearray([reg]), self.buf, in_end=2)
         return self.buf[0] << 8 | self.buf[1]
+

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -157,14 +157,16 @@ class ADS1x15:
 
     def _read(self, pin):
         """Perform an ADC read. Returns the signed integer result of the read."""
-        # Immediately return conversion register result if in CONTINUOUS mode and pin has not changed
+        # Immediately return conversion register result if in CONTINUOUS mode
+        # and pin has not changed
         if self.mode == Mode.CONTINUOUS and self._last_pin_read == pin:
             return self._conversion_value(self.get_last_result(True))
 
         # Assign last pin read if in SINGLE mode or first sample in CONTINUOUS mode on this pin
         self._last_pin_read = pin
 
-        # Configure ADC every time before a conversion in SINGLE mode or changing channels in CONTINUOUS mode
+        # Configure ADC every time before a conversion in SINGLE mode 
+        # or changing channels in CONTINUOUS mode
         if self.mode == Mode.SINGLE:
             config = _ADS1X15_CONFIG_OS_SINGLE
         else:

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -165,7 +165,7 @@ class ADS1x15:
         # Assign last pin read if in SINGLE mode or first sample in CONTINUOUS mode on this pin
         self._last_pin_read = pin
 
-        # Configure ADC every time before a conversion in SINGLE mode 
+        # Configure ADC every time before a conversion in SINGLE mode
         # or changing channels in CONTINUOUS mode
         if self.mode == Mode.SINGLE:
             config = _ADS1X15_CONFIG_OS_SINGLE
@@ -224,4 +224,3 @@ class ADS1x15:
             else:
                 i2c.write_then_readinto(bytearray([reg]), self.buf, in_end=2)
         return self.buf[0] << 8 | self.buf[1]
-

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -160,10 +160,10 @@ class ADS1x15:
         # Immediately return conversion register result if in CONTINUOUS mode and pin has not changed
         if self.mode == Mode.CONTINUOUS and self._last_pin_read == pin:
             return self._conversion_value(self.get_last_result(True))
-        
+
         # Assign last pin read if in SINGLE mode or first sample in CONTINUOUS mode on this pin
         self._last_pin_read = pin
-        
+
         # Configure ADC every time before a conversion in SINGLE mode or changing channels in CONTINUOUS mode
         if self.mode == Mode.SINGLE:
             config = _ADS1X15_CONFIG_OS_SINGLE

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -10,6 +10,9 @@ RATE = 3300
 SAMPLES = 1000
 
 # Create the I2C bus with a fast frequency
+# NOTE: Your device may not respect the frequency setting
+#       Raspberry Pis must change this in /boot/config.txt
+
 i2c = busio.I2C(board.SCL, board.SDA, frequency=1000000)
 
 # Create the ADC object using the I2C bus
@@ -26,15 +29,22 @@ repeats = 0
 
 data = [None] * SAMPLES
 
+time_last_sample = time.monotonic()
 start = time.monotonic()
 
 # Read the same channel over and over
 for i in range(SAMPLES):
+    # Wait for expected conversion finish time
+    while time.monotonic() < (time_last_sample + (1.0 / ads.data_rate)):
+        pass
+
+    # Read conversion value for ADC channel
+    time_last_sample = time.monotonic()
     data[i] = chan0.value
+
     # Detect repeated values due to over polling
     if data[i] == data[i - 1]:
         repeats += 1
-
 
 end = time.monotonic()
 total_time = end - start

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -31,6 +31,7 @@ start = time.monotonic()
 # Read the same channel over and over
 for i in range(SAMPLES):
     data[i] = chan0.value
+    # Detect repeated values due to over polling
     if data[i] == data[i-1]:
         repeats += 1
 
@@ -40,7 +41,7 @@ total_time = end - start
 
 rate_reported = SAMPLES / total_time
 rate_actual = (SAMPLES-repeats) / total_time
-# NOTE: cannot detect conversion rates higher than polling rate
+# NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
 print("")

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -22,6 +22,8 @@ chan0 = AnalogIn(ads, ADS.P0)
 ads.mode = Mode.CONTINUOUS
 ads.data_rate = RATE
 
+repeats = 0
+
 data = [None] * SAMPLES
 
 start = time.monotonic()
@@ -29,9 +31,26 @@ start = time.monotonic()
 # Read the same channel over and over
 for i in range(SAMPLES):
     data[i] = chan0.value
+    if data[i] == data[i-1]:
+        repeats += 1
+
 
 end = time.monotonic()
 total_time = end - start
 
-print("Time of capture: {}s".format(total_time))
-print("Sample rate requested={} actual={}".format(RATE, SAMPLES / total_time))
+rate_reported = SAMPLES / total_time
+rate_actual = (SAMPLES-repeats) / total_time
+# NOTE: cannot detect conversion rates higher than polling rate
+
+print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
+print("")
+print("Configured:")
+print("    Requested       = {:5d}    sps".format(RATE))
+print("    Reported        = {:5d}    sps".format(ads.data_rate))
+print("")
+print("Actual:")
+print("    Polling Rate    = {:8.2f} sps".format(rate_reported))
+print("                      {:9.2%}".format(rate_reported / RATE))
+print("    Repeats         = {:5d}".format(repeats))
+print("    Conversion Rate = {:8.2f} sps   (estimated)".format(rate_actual))
+

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -41,7 +41,8 @@ total_time = end - start
 
 rate_reported = SAMPLES / total_time
 rate_actual = (SAMPLES - repeats) / total_time
-# NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
+# NOTE: leave input floating to pickup some random noise
+#       This cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))
 print("")

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -27,7 +27,7 @@ ads.data_rate = RATE
 
 # First ADC channel read in continuous mode configures device
 # and waits 2 conversion cycles
-chan0.value
+_ = chan0.value
 
 sample_interval = 1.0 / ads.data_rate
 

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -25,6 +25,10 @@ chan0 = AnalogIn(ads, ADS.P0)
 ads.mode = Mode.CONTINUOUS
 ads.data_rate = RATE
 
+# First ADC channel read in continuous mode configures device
+# and waits 2 conversion cycles
+chan0.value
+
 sample_interval = 1.0 / ads.data_rate
 
 repeats = 0
@@ -32,8 +36,8 @@ skips = 0
 
 data = [None] * SAMPLES
 
-time_next_sample = time.monotonic()
 start = time.monotonic()
+time_next_sample = start + sample_interval
 
 # Read the same channel over and over
 for i in range(SAMPLES):

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -25,22 +25,31 @@ chan0 = AnalogIn(ads, ADS.P0)
 ads.mode = Mode.CONTINUOUS
 ads.data_rate = RATE
 
+sample_interval = 1.0 / ads.data_rate
+
 repeats = 0
+skips = 0
 
 data = [None] * SAMPLES
 
-time_last_sample = time.monotonic()
+time_next_sample = time.monotonic()
 start = time.monotonic()
 
 # Read the same channel over and over
 for i in range(SAMPLES):
     # Wait for expected conversion finish time
-    while time.monotonic() < (time_last_sample + (1.0 / ads.data_rate)):
+    while time.monotonic() < (time_next_sample):
         pass
 
     # Read conversion value for ADC channel
-    time_last_sample = time.monotonic()
     data[i] = chan0.value
+
+    # Loop timing
+    time_last_sample = time.monotonic()
+    time_next_sample = time_next_sample + sample_interval
+    if time_last_sample > (time_next_sample + sample_interval):
+        skips += 1
+        time_next_sample = time.monotonic() + sample_interval
 
     # Detect repeated values due to over polling
     if data[i] == data[i - 1]:
@@ -63,5 +72,6 @@ print("")
 print("Actual:")
 print("    Polling Rate    = {:8.2f} sps".format(rate_reported))
 print("                      {:9.2%}".format(rate_reported / RATE))
+print("    Skipped         = {:5d}".format(skips))
 print("    Repeats         = {:5d}".format(repeats))
 print("    Conversion Rate = {:8.2f} sps   (estimated)".format(rate_actual))

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -32,7 +32,7 @@ start = time.monotonic()
 for i in range(SAMPLES):
     data[i] = chan0.value
     # Detect repeated values due to over polling
-    if data[i] == data[i-1]:
+    if data[i] == data[i - 1]:
         repeats += 1
 
 
@@ -40,7 +40,7 @@ end = time.monotonic()
 total_time = end - start
 
 rate_reported = SAMPLES / total_time
-rate_actual = (SAMPLES-repeats) / total_time
+rate_actual = (SAMPLES - repeats) / total_time
 # NOTE: leave input floating to pickup some random noise, this cannot estimate conversion rates higher than polling rate
 
 print("Took {:5.3f} s to acquire {:d} samples.".format(total_time, SAMPLES))

--- a/examples/ads1x15_fast_read.py
+++ b/examples/ads1x15_fast_read.py
@@ -54,4 +54,3 @@ print("    Polling Rate    = {:8.2f} sps".format(rate_reported))
 print("                      {:9.2%}".format(rate_reported / RATE))
 print("    Repeats         = {:5d}".format(repeats))
 print("    Conversion Rate = {:8.2f} sps   (estimated)".format(rate_actual))
-


### PR DESCRIPTION
Previously polling rate (apparent sample rate) was limited purely by I2C speed, script will now wait a full conversion cycle until it next reads the conversion result.

Requires #61 to be merged first.

With `RATE=250` and `i2c_baudrate=1000000` (1 MHz)

**_Old_**
```
Took 0.139 s to acquire 1000 samples.

Configured:
    Requested       =   250    sps
    Reported        =   250    sps

Actual:
    Polling Rate    =  7171.07 sps
                       2868.43%
    Repeats         =   966
    Conversion Rate =   243.82 sps   (estimated)
```

**_New_**
```
Took 4.009 s to acquire 1000 samples.

Configured:
    Requested       =   250    sps
    Reported        =   250    sps

Actual:
    Polling Rate    =   249.41 sps
                         99.76%
    Repeats         =    25
    Conversion Rate =   243.18 sps   (estimated)
```

---
Also constrains polling rate at any other valid sample rate, eg. `RATE=3300` and `i2c_baudrate=1000000` (1 MHz)
**_New_**
```
Took 0.309 s to acquire 1000 samples.

Configured:
    Requested       =  3300    sps
    Reported        =  3300    sps

Actual:
    Polling Rate    =  3234.39 sps
                         98.01%
    Repeats         =    25
    Conversion Rate =  3153.53 sps   (estimated)
```

