### PR TITLE
Fix documentation

### DIFF
--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -28,9 +28,13 @@ _ADS1015_CONFIG_DR = {
 
 # Pins
 P0 = 0
+"""Analog Pin 0"""
 P1 = 1
+"""Analog Pin 1"""
 P2 = 2
+"""Analog Pin 2"""
 P3 = 3
+"""Analog Pin 3"""
 
 
 class ADS1015(ADS1x15):

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -29,9 +29,13 @@ _ADS1115_CONFIG_DR = {
 
 # Pins
 P0 = 0
+"""Analog Pin 0"""
 P1 = 1
+"""Analog Pin 1"""
 P2 = 2
+"""Analog Pin 2"""
 P3 = 3
+"""Analog Pin 3"""
 
 
 class ADS1115(ADS1x15):

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -48,11 +48,21 @@ class Mode:
     # values here are masks for setting MODE bit in Config Register
     # pylint: disable=too-few-public-methods
     CONTINUOUS = 0x0000
+    """Continuous Mode"""
     SINGLE = 0x0100
+    """Single-Shot Mode"""
 
 
 class ADS1x15:
-    """Base functionality for ADS1x15 analog to digital converters."""
+    """Base functionality for ADS1x15 analog to digital converters.
+
+    :param ~busio.I2C i2c: The I2C bus the device is connected to.
+    :param float gain: The ADC gain.
+    :param int data_rate: The data rate for ADC conversion in samples per second.
+                          Default value depends on the device.
+    :param Mode mode: The conversion mode, defaults to `Mode.SINGLE`.
+    :param int address: The I2C address of the device.
+    """
 
     def __init__(
         self,

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -126,9 +126,8 @@ class ADS1x15:
     def read(self, pin: Pin, is_differential: bool = False) -> int:
         """I2C Interface for ADS1x15-based ADCs reads.
 
-        params:
-            :param pin: individual or differential pin.
-            :param bool is_differential: single-ended or differential read.
+        :param ~microcontroller.Pin pin: individual or differential pin.
+        :param bool is_differential: single-ended or differential read.
         """
         pin = pin if is_differential else pin + 0x04
         return self._read(pin)

--- a/adafruit_ads1x15/analog_in.py
+++ b/adafruit_ads1x15/analog_in.py
@@ -22,17 +22,16 @@ _ADS1X15_PGA_RANGE = {2 / 3: 6.144, 1: 4.096, 2: 2.048, 4: 1.024, 8: 0.512, 16: 
 
 
 class AnalogIn:
-    """AnalogIn Mock Implementation for ADC Reads."""
+    """AnalogIn Mock Implementation for ADC Reads.
+
+    :param ADS1x15 ads: The ads object.
+    :param int positive_pin: Required pin for single-ended.
+    :param int negative_pin: Optional pin for differential reads.
+    """
 
     def __init__(
         self, ads: ADS1x15, positive_pin: int, negative_pin: Optional[int] = None
     ):
-        """AnalogIn
-
-        :param ads: The ads object.
-        :param ~digitalio.DigitalInOut positive_pin: Required pin for single-ended.
-        :param ~digitalio.DigitalInOut negative_pin: Optional pin for differential reads.
-        """
         self._ads = ads
         self._pin_setting = positive_pin
         self._negative_pin = negative_pin


### PR DESCRIPTION
Parameters list in the wrong place for init (was ignored).
Added parameters description for the base class init.
List pin names.
List modes.