### PR TITLE
Adding typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ _build
 .idea
 .vscode
 *~
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _build
 
 # Virtual environment-specific files
 .env
+.venv
 
 # MacOS-specific files
 *.DS_Store
@@ -45,4 +46,3 @@ _build
 .idea
 .vscode
 *~
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ _build
 .idea
 .vscode
 *~
-.venv
+.env

--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -61,6 +61,5 @@ class ADS1015(ADS1x15):
         return 1600
 
     def _conversion_value(self, raw_adc: int) -> int:
-        raw_adc = raw_adc.to_bytes(2, "big")
-        value = struct.unpack(">h", raw_adc)[0]
+        value = struct.unpack(">h", raw_adc.to_bytes(2, "big"))[0]
         return value >> 4

--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -41,19 +41,19 @@ class ADS1015(ADS1x15):
     """Class for the ADS1015 12 bit ADC."""
 
     @property
-    def bits(self):
+    def bits(self) -> int:
         """The ADC bit resolution."""
         return 12
 
     @property
-    def rates(self):
+    def rates(self) -> list[int]:
         """Possible data rate settings."""
         r = list(_ADS1015_CONFIG_DR.keys())
         r.sort()
         return r
 
     @property
-    def rate_config(self):
+    def rate_config(self) -> dict[int, int]:
         """Rate configuration masks."""
         return _ADS1015_CONFIG_DR
 

--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -64,7 +64,7 @@ class ADS1015(ADS1x15):
         """Rate configuration masks."""
         return _ADS1015_CONFIG_DR
 
-    def _data_rate_default(self) -> int:
+    def _data_rate_default(self) -> Literal[1600]:
         return 1600
 
     def _conversion_value(self, raw_adc: int) -> int:

--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -11,6 +11,7 @@ CircuitPython driver for ADS1015 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
+from typing import Dict, List
 
 # pylint: disable=unused-import
 from .ads1x15 import ADS1x15, Mode
@@ -46,14 +47,14 @@ class ADS1015(ADS1x15):
         return 12
 
     @property
-    def rates(self) -> list[int]:
+    def rates(self) -> List[int]:
         """Possible data rate settings."""
         r = list(_ADS1015_CONFIG_DR.keys())
         r.sort()
         return r
 
     @property
-    def rate_config(self) -> dict[int, int]:
+    def rate_config(self) -> Dict[int, int]:
         """Rate configuration masks."""
         return _ADS1015_CONFIG_DR
 

--- a/adafruit_ads1x15/ads1015.py
+++ b/adafruit_ads1x15/ads1015.py
@@ -11,7 +11,13 @@ CircuitPython driver for ADS1015 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
-from typing import Dict, List
+
+try:
+    from typing import Dict, List
+
+    from typing_extensions import Literal
+except ImportError:
+    pass
 
 # pylint: disable=unused-import
 from .ads1x15 import ADS1x15, Mode
@@ -42,7 +48,7 @@ class ADS1015(ADS1x15):
     """Class for the ADS1015 12 bit ADC."""
 
     @property
-    def bits(self) -> int:
+    def bits(self) -> Literal[12]:
         """The ADC bit resolution."""
         return 12
 

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -62,6 +62,5 @@ class ADS1115(ADS1x15):
         return 128
 
     def _conversion_value(self, raw_adc: int) -> int:
-        raw_adc = raw_adc.to_bytes(2, "big")
-        value = struct.unpack(">h", raw_adc)[0]
+        value = struct.unpack(">h", raw_adc.to_bytes(2, "big"))[0]
         return value

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -11,7 +11,13 @@ CircuitPython driver for 1115 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
-from typing import Dict, List
+
+try:
+    from typing import Dict, List
+
+    from typing_extensions import Literal
+except ImportError:
+    pass
 
 # pylint: disable=unused-import
 from .ads1x15 import ADS1x15, Mode
@@ -43,7 +49,7 @@ class ADS1115(ADS1x15):
     """Class for the ADS1115 16 bit ADC."""
 
     @property
-    def bits(self) -> int:
+    def bits(self) -> Literal[16]:
         """The ADC bit resolution."""
         return 16
 

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -42,19 +42,19 @@ class ADS1115(ADS1x15):
     """Class for the ADS1115 16 bit ADC."""
 
     @property
-    def bits(self):
+    def bits(self) -> int:
         """The ADC bit resolution."""
         return 16
 
     @property
-    def rates(self):
+    def rates(self) -> list[int]:
         """Possible data rate settings."""
         r = list(_ADS1115_CONFIG_DR.keys())
         r.sort()
         return r
 
     @property
-    def rate_config(self):
+    def rate_config(self) -> dict[int, int]:
         """Rate configuration masks."""
         return _ADS1115_CONFIG_DR
 

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -65,7 +65,7 @@ class ADS1115(ADS1x15):
         """Rate configuration masks."""
         return _ADS1115_CONFIG_DR
 
-    def _data_rate_default(self) -> int:
+    def _data_rate_default(self) -> Literal[128]:
         return 128
 
     def _conversion_value(self, raw_adc: int) -> int:

--- a/adafruit_ads1x15/ads1115.py
+++ b/adafruit_ads1x15/ads1115.py
@@ -11,6 +11,7 @@ CircuitPython driver for 1115 ADCs.
 * Author(s): Carter Nelson
 """
 import struct
+from typing import Dict, List
 
 # pylint: disable=unused-import
 from .ads1x15 import ADS1x15, Mode
@@ -47,14 +48,14 @@ class ADS1115(ADS1x15):
         return 16
 
     @property
-    def rates(self) -> list[int]:
+    def rates(self) -> List[int]:
         """Possible data rate settings."""
         r = list(_ADS1115_CONFIG_DR.keys())
         r.sort()
         return r
 
     @property
-    def rate_config(self) -> dict[int, int]:
+    def rate_config(self) -> Dict[int, int]:
         """Rate configuration masks."""
         return _ADS1115_CONFIG_DR
 

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -20,7 +20,7 @@ from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
 
 try:
-    from typing import Dict, List, Literal, Optional, Union
+    from typing import Dict, List, Optional
 
     from busio import I2C
     from microcontroller import Pin
@@ -83,7 +83,7 @@ class ADS1x15:
         self.i2c_device = I2CDevice(i2c, address)
 
     @property
-    def bits(self) -> Union[Literal[12], Literal[16]]:
+    def bits(self) -> int:
         """The ADC bit resolution."""
         raise NotImplementedError("Subclass must implement bits property.")
 

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -77,11 +77,8 @@ class ADS1x15:
         # pylint: disable=too-many-arguments
         self._last_pin_read = None
         self.buf = bytearray(3)
-        self._gain = gain
         self.gain = gain
-        self._data_rate = self._data_rate_default() if data_rate is None else data_rate
         self.data_rate = self._data_rate_default() if data_rate is None else data_rate
-        self._mode = mode
         self.mode = mode
         self.i2c_device = I2CDevice(i2c, address)
 

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -15,11 +15,13 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15.git"
 
 import time
-from micropython import const
+
 from adafruit_bus_device.i2c_device import I2CDevice
+from micropython import const
 
 try:
     from typing import Optional
+
     from busio import I2C
     from microcontroller import Pin
 except ImportError:
@@ -69,15 +71,17 @@ class ADS1x15:
         i2c: I2C,
         gain: float = 1,
         data_rate: Optional[int] = None,
-        mode: Mode = Mode.SINGLE,
+        mode: int = Mode.SINGLE,
         address: int = _ADS1X15_DEFAULT_ADDRESS,
     ):
         # pylint: disable=too-many-arguments
         self._last_pin_read = None
         self.buf = bytearray(3)
-        self._data_rate = self._gain = self._mode = None
+        self._gain:float
         self.gain = gain
+        self._data_rate: int
         self.data_rate = self._data_rate_default() if data_rate is None else data_rate
+        self._mode:int
         self.mode = mode
         self.i2c_device = I2CDevice(i2c, address)
 
@@ -128,7 +132,7 @@ class ADS1x15:
         return self._mode
 
     @mode.setter
-    def mode(self, mode: Mode):
+    def mode(self, mode: int):
         if mode not in (Mode.CONTINUOUS, Mode.SINGLE):
             raise ValueError("Unsupported mode.")
         self._mode = mode

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -20,7 +20,7 @@ from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
 
 try:
-    from typing import Optional
+    from typing import Optional, List, Dict
 
     from busio import I2C
     from microcontroller import Pin
@@ -103,12 +103,12 @@ class ADS1x15:
         self._data_rate = rate
 
     @property
-    def rates(self) -> list[int]:
+    def rates(self) -> List[int]:
         """Possible data rate settings."""
         raise NotImplementedError("Subclass must implement rates property.")
 
     @property
-    def rate_config(self) -> dict[int, int]:
+    def rate_config(self) -> Dict[int, int]:
         """Rate configuration masks."""
         raise NotImplementedError("Subclass must implement rate_config property.")
 
@@ -125,7 +125,7 @@ class ADS1x15:
         self._gain = gain
 
     @property
-    def gains(self) -> list[float]:
+    def gains(self) -> List[float]:
         """Possible gain settings."""
         g = list(_ADS1X15_CONFIG_GAIN.keys())
         g.sort()

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -86,53 +86,58 @@ class ADS1x15:
         self.i2c_device = I2CDevice(i2c, address)
 
     @property
-    def data_rate(self):
+    def bits(self) -> int:
+        """The ADC bit resolution."""
+        raise NotImplementedError("Subclass must implement bits property.")
+
+    @property
+    def data_rate(self) -> int:
         """The data rate for ADC conversion in samples per second."""
         return self._data_rate
 
     @data_rate.setter
-    def data_rate(self, rate: int):
+    def data_rate(self, rate: int) -> None:
         possible_rates = self.rates
         if rate not in possible_rates:
             raise ValueError("Data rate must be one of: {}".format(possible_rates))
         self._data_rate = rate
 
     @property
-    def rates(self):
+    def rates(self) -> list[int]:
         """Possible data rate settings."""
         raise NotImplementedError("Subclass must implement rates property.")
 
     @property
-    def rate_config(self):
+    def rate_config(self) -> dict[int, int]:
         """Rate configuration masks."""
         raise NotImplementedError("Subclass must implement rate_config property.")
 
     @property
-    def gain(self):
+    def gain(self) -> float:
         """The ADC gain."""
         return self._gain
 
     @gain.setter
-    def gain(self, gain: float):
+    def gain(self, gain: float) -> None:
         possible_gains = self.gains
         if gain not in possible_gains:
             raise ValueError("Gain must be one of: {}".format(possible_gains))
         self._gain = gain
 
     @property
-    def gains(self):
+    def gains(self) -> list[float]:
         """Possible gain settings."""
         g = list(_ADS1X15_CONFIG_GAIN.keys())
         g.sort()
         return g
 
     @property
-    def mode(self):
+    def mode(self) -> int:
         """The ADC conversion mode."""
         return self._mode
 
     @mode.setter
-    def mode(self, mode: int):
+    def mode(self, mode: int) -> None:
         if mode not in (Mode.CONTINUOUS, Mode.SINGLE):
             raise ValueError("Unsupported mode.")
         self._mode = mode

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -77,11 +77,11 @@ class ADS1x15:
         # pylint: disable=too-many-arguments
         self._last_pin_read = None
         self.buf = bytearray(3)
-        self._gain:float
+        self._gain: float
         self.gain = gain
         self._data_rate: int
         self.data_rate = self._data_rate_default() if data_rate is None else data_rate
-        self._mode:int
+        self._mode: int
         self.mode = mode
         self.i2c_device = I2CDevice(i2c, address)
 

--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -20,7 +20,7 @@ from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
 
 try:
-    from typing import Optional, List, Dict
+    from typing import Dict, List, Literal, Optional, Union
 
     from busio import I2C
     from microcontroller import Pin
@@ -77,16 +77,16 @@ class ADS1x15:
         # pylint: disable=too-many-arguments
         self._last_pin_read = None
         self.buf = bytearray(3)
-        self._gain: float
+        self._gain = gain
         self.gain = gain
-        self._data_rate: int
+        self._data_rate = self._data_rate_default() if data_rate is None else data_rate
         self.data_rate = self._data_rate_default() if data_rate is None else data_rate
-        self._mode: int
+        self._mode = mode
         self.mode = mode
         self.i2c_device = I2CDevice(i2c, address)
 
     @property
-    def bits(self) -> int:
+    def bits(self) -> Union[Literal[12], Literal[16]]:
         """The ADC bit resolution."""
         raise NotImplementedError("Subclass must implement bits property.")
 

--- a/adafruit_ads1x15/analog_in.py
+++ b/adafruit_ads1x15/analog_in.py
@@ -12,7 +12,8 @@ differential ADC readings.
 """
 
 try:
-    from typing import Optional
+    from typing import Optional, cast
+
     from .ads1x15 import ADS1x15
 except ImportError:
     pass
@@ -37,7 +38,7 @@ class AnalogIn:
         self._negative_pin = negative_pin
         self.is_differential = False
         if negative_pin is not None:
-            pins = (self._pin_setting, self._negative_pin)
+            pins = (self._pin_setting, cast(int, self._negative_pin))
             if pins not in _ADS1X15_DIFF_CHANNELS:
                 raise ValueError(
                     "Differential channels must be one of: {}".format(

--- a/adafruit_ads1x15/analog_in.py
+++ b/adafruit_ads1x15/analog_in.py
@@ -12,8 +12,7 @@ differential ADC readings.
 """
 
 try:
-    from typing import Optional, cast
-
+    from typing import Optional
     from .ads1x15 import ADS1x15
 except ImportError:
     pass
@@ -38,7 +37,7 @@ class AnalogIn:
         self._negative_pin = negative_pin
         self.is_differential = False
         if negative_pin is not None:
-            pins = (self._pin_setting, cast(int, self._negative_pin))
+            pins = (self._pin_setting, self._negative_pin)
             if pins not in _ADS1X15_DIFF_CHANNELS:
                 raise ValueError(
                     "Differential channels must be one of: {}".format(
@@ -49,14 +48,14 @@ class AnalogIn:
             self.is_differential = True
 
     @property
-    def value(self):
+    def value(self) -> int:
         """Returns the value of an ADC pin as an integer."""
         return self._ads.read(
             self._pin_setting, is_differential=self.is_differential
         ) << (16 - self._ads.bits)
 
     @property
-    def voltage(self):
+    def voltage(self) -> float:
         """Returns the voltage from the ADC pin as a floating point value."""
         volts = self.value * _ADS1X15_PGA_RANGE[self._ads.gain] / 32767
         return volts

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+typing-extensions~=4.0


### PR DESCRIPTION
Adding `.venv` to the ignore list so it doesn't accidentally get added
Adding py.typed file to signify this library has typing information
Fixed typing errors found by mypy

Addresses issue #83 