### PR TITLE
Avoid error when microcontroller>Pin import fails

### DIFF
--- a/adafruit_ads1x15/ads1x15.py
+++ b/adafruit_ads1x15/ads1x15.py
@@ -25,7 +25,10 @@ try:
     from busio import I2C
     from microcontroller import Pin
 except ImportError:
-    pass
+    # define Pin to avoid the error:
+    #   def read(self, pin: Pin, is_differential: bool = False) -> int:
+    #   NameError: name 'Pin' is not defined
+    Pin = None
 
 _ADS1X15_DEFAULT_ADDRESS = const(0x48)
 _ADS1X15_POINTER_CONVERSION = const(0x00)


### PR DESCRIPTION
When running

```
>>> from adafruit_ads1x15.analog_in import AnalogIn
```

without having python3-libgpiod installed, I got this not-very-clear error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/dist-packages/adafruit_ads1x15/analog_in.py", line 16, in <module>
    from .ads1x15 import ADS1x15
  File "/usr/local/lib/python3.9/dist-packages/adafruit_ads1x15/ads1x15.py", line 58, in <module>
    class ADS1x15:
  File "/usr/local/lib/python3.9/dist-packages/adafruit_ads1x15/ads1x15.py", line 142, in ADS1x15
    def read(self, pin: Pin, is_differential: bool = False) -> int:
NameError: name 'Pin' is not defined
```

This happens because the import of microcontroller > Pin here

https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/blob/588051a710904c07556989242c805b1a53de9dfb/adafruit_ads1x15/ads1x15.py#L22-L28

is failing due to the lack of python3-libgpiod. And the actually useful error message is not shown as it gets caught by try, which is ok, as microcontroller>Pin is not needed for running the thing.

The error I observed is caused by the mention of `Pin` here:

https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/blob/588051a710904c07556989242c805b1a53de9dfb/adafruit_ads1x15/ads1x15.py#L142

https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/blob/588051a710904c07556989242c805b1a53de9dfb/adafruit_ads1x15/ads1x15.py#L163

No idea why the Python interpreter (I am on Python 3.9.2) cares about the type hints.