### PR TITLE
remove ruff rule E999 deprecated in v0.5.0 and removed in v0.8.0

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,6 @@ extend-select = [
   "PLC2401",  # non-ascii-name
   "PLC2801",  # unnecessary-dunder-call
   "PLC3002",  # unnecessary-direct-lambda-call
-  "E999",  # syntax-error
   "PLE0101",  # return-in-init
   "F706",  # return-outside-function
   "F704",  # yield-outside-function


### PR DESCRIPTION
It results in the following error:
`ERROR Failed to resolve settings for ruff.toml: Rule `E999` was removed and cannot be selected.`